### PR TITLE
Fix SetPacketFilterTable/StoreTable marshaling a slice header instead of filter data

### DIFF
--- a/driver/static_filters.go
+++ b/driver/static_filters.go
@@ -4,7 +4,6 @@ package driver
 
 import (
 	"fmt"
-	"unsafe"
 
 	A "github.com/wiresock/ndisapi-go"
 )
@@ -121,19 +120,22 @@ func (f *StaticFilters) Contains(filter *Filter) bool {
 }
 
 // StoreTable stores the current filter table to the driver.
+//
+// The table is built with a properly allocated StaticFilters slice and handed to
+// SetPacketFilterTable, which marshals it into the contiguous layout the driver expects.
+// (The previous implementation overlaid *StaticFilterTable on a zeroed []byte and wrote
+// through the resulting nil slice header, which panics with index-out-of-range as soon as
+// any filter is present.)
 func (f *StaticFilters) StoreTable() error {
 	filterSize := len(f.Filters)
-	tableBuffer := make([]byte, int(unsafe.Sizeof(A.StaticFilterTable{}))+(filterSize)*int(unsafe.Sizeof(A.StaticFilter{})))
-	table := (*A.StaticFilterTable)(unsafe.Pointer(&tableBuffer[0]))
 
-	for i := range tableBuffer {
-		tableBuffer[i] = 0
+	table := &A.StaticFilterTable{
+		TableSize:     uint32(filterSize),
+		StaticFilters: make([]A.StaticFilter, filterSize),
 	}
 
-	table.TableSize = uint32(filterSize)
-
-	for i, filter := range f.Filters {
-		table.StaticFilters[i] = *f.toStaticFilter(&filter)
+	for i := range f.Filters {
+		table.StaticFilters[i] = *f.toStaticFilter(&f.Filters[i])
 	}
 
 	if err := f.SetPacketFilterTable(table); err != nil {

--- a/ndisapi_static.go
+++ b/ndisapi_static.go
@@ -556,7 +556,7 @@ func marshalStaticFilterTable(packet *StaticFilterTable) []byte {
 	// written into the header can never disagree with the filter data that follows it.
 	// packet.TableSize is intentionally ignored to rule out that silent mismatch.
 	tableSize := uint32(len(packet.StaticFilters))
-	bufferSize := int(unsafe.Sizeof(InitialStaticFilterTable{})) + (int(tableSize)-AnySize)*int(unsafe.Sizeof(StaticFilter{}))
+	bufferSize := int(staticFilterTableHeaderSize) + int(tableSize)*int(unsafe.Sizeof(StaticFilter{}))
 	tableBuffer := make([]byte, bufferSize)
 
 	// Header: TableSize at offset 0, Padding at offset 4 (left zero).

--- a/ndisapi_static.go
+++ b/ndisapi_static.go
@@ -491,6 +491,11 @@ type InitialStaticFilterTable struct {
 	StaticFilters [AnySize]StaticFilter
 }
 
+// staticFilterTableHeaderSize is the byte offset at which the contiguous STATIC_FILTER array
+// begins (past TableSize + Padding). Both the read path (GetPacketFilterTable) and the write
+// path (marshalStaticFilterTable) key off this so the layout cannot drift if the header changes.
+const staticFilterTableHeaderSize = unsafe.Offsetof(InitialStaticFilterTable{}.StaticFilters)
+
 // StaticFilterTable represents a table of static filters
 type StaticFilterTable struct {
 	TableSize     uint32
@@ -500,26 +505,64 @@ type StaticFilterTable struct {
 
 // StaticFilterWithPosition represents a static filter with a specific insertion position.
 type StaticFilterWithPosition struct {
-	Position     uint32
+	Position      uint32
 	StaticFilters StaticFilter
 }
 
 // SetPacketFilterTable sets the static packet filter table for the Windows Packet Filter driver.
+//
+// StaticFilterTable.StaticFilters is a Go slice, so its in-memory layout is a 24-byte
+// slice header (ptr/len/cap), not the contiguous STATIC_FILTER array the driver expects.
+// Passing unsafe.Pointer(packet) directly makes the driver read that slice header as the
+// first STATIC_FILTER (garbage). We therefore marshal the table into a contiguous buffer
+// laid out as [TableSize][Padding][filter0][filter1]... with the filters starting at
+// offset 8 - mirroring exactly how GetPacketFilterTable reads it back.
 func (a *NdisApi) SetPacketFilterTable(packet *StaticFilterTable) error {
-	var size uint32 = 0
-	if packet != nil {
-		size = uint32(unsafe.Sizeof(InitialStaticFilterTable{})) + (packet.TableSize-1)*uint32(unsafe.Sizeof(StaticFilter{}))
+	if packet == nil {
+		return a.DeviceIoControl(
+			IOCTL_NDISRD_SET_PACKET_FILTERS,
+			nil,
+			0,
+			nil,
+			0,
+			&a.bytesReturned,
+			nil,
+		)
 	}
+
+	tableBuffer := marshalStaticFilterTable(packet)
 
 	return a.DeviceIoControl(
 		IOCTL_NDISRD_SET_PACKET_FILTERS,
-		unsafe.Pointer(packet),
-		size,
+		unsafe.Pointer(&tableBuffer[0]),
+		uint32(len(tableBuffer)),
 		nil,
 		0,
 		&a.bytesReturned,
 		nil,
 	)
+}
+
+// marshalStaticFilterTable serializes a StaticFilterTable into the contiguous byte layout
+// expected by the driver: [TableSize uint32][Padding uint32][filter0][filter1]... with the
+// STATIC_FILTER array starting at offset 8. This is the exact inverse of the read path in
+// GetPacketFilterTable and is kept as a standalone function so it can be unit-tested without
+// a live driver.
+func marshalStaticFilterTable(packet *StaticFilterTable) []byte {
+	tableSize := packet.TableSize
+	bufferSize := int(unsafe.Sizeof(InitialStaticFilterTable{})) + (int(tableSize)-AnySize)*int(unsafe.Sizeof(StaticFilter{}))
+	tableBuffer := make([]byte, bufferSize)
+
+	// Header: TableSize at offset 0, Padding at offset 4 (left zero).
+	*(*uint32)(unsafe.Pointer(&tableBuffer[0])) = tableSize
+
+	// Filters laid out contiguously starting right after the header.
+	for i := 0; i < int(tableSize) && i < len(packet.StaticFilters); i++ {
+		offset := int(staticFilterTableHeaderSize) + i*int(unsafe.Sizeof(StaticFilter{}))
+		*(*StaticFilter)(unsafe.Pointer(&tableBuffer[offset])) = packet.StaticFilters[i]
+	}
+
+	return tableBuffer
 }
 
 // AddStaticFilterFront adds a static filter to the front of the filter list in the Windows Packet Filter driver.
@@ -551,7 +594,7 @@ func (a *NdisApi) AddStaticFilterBack(filter *StaticFilter) error {
 // InsertStaticFilter inserts a static filter at a specified position in the filter chain.
 func (a *NdisApi) InsertStaticFilter(filter *StaticFilter, position uint32) error {
 	staticFilter := StaticFilterWithPosition{
-		Position:     position,
+		Position:      position,
 		StaticFilters: *filter,
 	}
 	return a.DeviceIoControl(
@@ -638,7 +681,7 @@ func (a *NdisApi) GetPacketFilterTable(tableSize uint32) (*StaticFilterTable, er
 	}
 
 	for i := 0; i < int(tableSize); i++ {
-		offset := 8 + i*int(unsafe.Sizeof(StaticFilter{}))
+		offset := int(staticFilterTableHeaderSize) + i*int(unsafe.Sizeof(StaticFilter{}))
 		filterList.StaticFilters[i] = *(*StaticFilter)(unsafe.Pointer(&tableBuffer[offset]))
 	}
 

--- a/ndisapi_static.go
+++ b/ndisapi_static.go
@@ -517,6 +517,9 @@ type StaticFilterWithPosition struct {
 // first STATIC_FILTER (garbage). We therefore marshal the table into a contiguous buffer
 // laid out as [TableSize][Padding][filter0][filter1]... with the filters starting at
 // offset 8 - mirroring exactly how GetPacketFilterTable reads it back.
+//
+// The number of filters sent is taken from len(packet.StaticFilters); packet.TableSize is
+// ignored on send, so the header count and the filter data can never disagree.
 func (a *NdisApi) SetPacketFilterTable(packet *StaticFilterTable) error {
 	if packet == nil {
 		return a.DeviceIoControl(
@@ -549,7 +552,10 @@ func (a *NdisApi) SetPacketFilterTable(packet *StaticFilterTable) error {
 // GetPacketFilterTable and is kept as a standalone function so it can be unit-tested without
 // a live driver.
 func marshalStaticFilterTable(packet *StaticFilterTable) []byte {
-	tableSize := packet.TableSize
+	// The slice length is the single source of truth for the number of filters, so the count
+	// written into the header can never disagree with the filter data that follows it.
+	// packet.TableSize is intentionally ignored to rule out that silent mismatch.
+	tableSize := uint32(len(packet.StaticFilters))
 	bufferSize := int(unsafe.Sizeof(InitialStaticFilterTable{})) + (int(tableSize)-AnySize)*int(unsafe.Sizeof(StaticFilter{}))
 	tableBuffer := make([]byte, bufferSize)
 
@@ -557,7 +563,7 @@ func marshalStaticFilterTable(packet *StaticFilterTable) []byte {
 	*(*uint32)(unsafe.Pointer(&tableBuffer[0])) = tableSize
 
 	// Filters laid out contiguously starting right after the header.
-	for i := 0; i < int(tableSize) && i < len(packet.StaticFilters); i++ {
+	for i := 0; i < int(tableSize); i++ {
 		offset := int(staticFilterTableHeaderSize) + i*int(unsafe.Sizeof(StaticFilter{}))
 		*(*StaticFilter)(unsafe.Pointer(&tableBuffer[offset])) = packet.StaticFilters[i]
 	}

--- a/ndisapi_static_marshal_test.go
+++ b/ndisapi_static_marshal_test.go
@@ -69,6 +69,41 @@ func TestMarshalStaticFilterTable(t *testing.T) {
 	}
 }
 
+// TestMarshalStaticFilterTableLengthIsSourceOfTruth verifies that the slice length - not the
+// caller-supplied TableSize field - determines how many filters are marshaled, so a stale or
+// wrong TableSize can never produce a header count that disagrees with the filter data.
+func TestMarshalStaticFilterTableLengthIsSourceOfTruth(t *testing.T) {
+	table := &StaticFilterTable{
+		TableSize: 5, // deliberately wrong - only 2 filters actually present
+		StaticFilters: []StaticFilter{
+			{Adapter: Handle{1, 0, 0, 0, 0, 0, 0, 0}, FilterAction: 0x2000},
+			{Adapter: Handle{2, 0, 0, 0, 0, 0, 0, 0}, FilterAction: 0x2001},
+		},
+	}
+
+	buf := marshalStaticFilterTable(table)
+
+	// Header count must reflect the slice length (2), not the bogus TableSize (5).
+	if got := *(*uint32)(unsafe.Pointer(&buf[0])); got != 2 {
+		t.Fatalf("header TableSize = %d, want 2 (slice length)", got)
+	}
+
+	// Buffer must be sized for 2 filters, not 5.
+	wantSize := int(unsafe.Sizeof(InitialStaticFilterTable{})) + (2-AnySize)*int(unsafe.Sizeof(StaticFilter{}))
+	if len(buf) != wantSize {
+		t.Fatalf("buffer size = %d, want %d (2 filters)", len(buf), wantSize)
+	}
+
+	// The two real filters must still be laid out correctly after the header.
+	for i := 0; i < 2; i++ {
+		offset := int(staticFilterTableHeaderSize) + i*int(unsafe.Sizeof(StaticFilter{}))
+		got := *(*StaticFilter)(unsafe.Pointer(&buf[offset]))
+		if got != table.StaticFilters[i] {
+			t.Errorf("filter[%d] mismatch:\n got = %+v\nwant = %+v", i, got, table.StaticFilters[i])
+		}
+	}
+}
+
 // TestMarshalStaticFilterTableEmpty ensures a zero-filter table marshals to just the 8-byte
 // header without panicking.
 func TestMarshalStaticFilterTableEmpty(t *testing.T) {

--- a/ndisapi_static_marshal_test.go
+++ b/ndisapi_static_marshal_test.go
@@ -1,0 +1,85 @@
+//go:build windows
+
+package ndisapi
+
+import (
+	"testing"
+	"unsafe"
+)
+
+// TestMarshalStaticFilterTable verifies that marshalStaticFilterTable lays the filters out
+// contiguously starting at offset 8 - the exact layout GetPacketFilterTable reads back - and
+// that the slice header is NOT what ends up on the wire. This is the regression test for the
+// SetPacketFilterTable slice-marshaling bug and needs no live driver.
+func TestMarshalStaticFilterTable(t *testing.T) {
+	const n = 3
+
+	table := &StaticFilterTable{
+		TableSize:     n,
+		StaticFilters: make([]StaticFilter, n),
+	}
+	for i := 0; i < n; i++ {
+		// Distinct, easily recognizable sentinel values per filter.
+		table.StaticFilters[i] = StaticFilter{
+			Adapter:        Handle{byte(i + 1), 0, 0, 0, 0, 0, 0, 0},
+			DirectionFlags: uint32(0x1000 + i),
+			FilterAction:   uint32(0x2000 + i),
+			ValidFields:    uint32(0x3000 + i),
+			PacketsIn:      uint64(0xAAAA0000 + i),
+		}
+	}
+
+	// Pin the driver contract: the STATIC_FILTER array must begin at offset 8 (TableSize +
+	// Padding). The marshaling and the read path both rely on this exact layout.
+	if staticFilterTableHeaderSize != 8 {
+		t.Fatalf("staticFilterTableHeaderSize = %d, want 8", staticFilterTableHeaderSize)
+	}
+
+	buf := marshalStaticFilterTable(table)
+
+	// Buffer size must match the formula used by GetPacketFilterTable.
+	wantSize := int(unsafe.Sizeof(InitialStaticFilterTable{})) + (n-AnySize)*int(unsafe.Sizeof(StaticFilter{}))
+	if len(buf) != wantSize {
+		t.Fatalf("buffer size = %d, want %d", len(buf), wantSize)
+	}
+
+	// Header: TableSize at offset 0.
+	if got := *(*uint32)(unsafe.Pointer(&buf[0])); got != n {
+		t.Fatalf("header TableSize = %d, want %d", got, n)
+	}
+
+	// Each filter must be readable contiguously after the header, exactly mirroring the read
+	// path in GetPacketFilterTable. StaticFilter has no pointers/slices/maps, so it is
+	// comparable - compare the whole struct, not a hand-picked subset of fields.
+	for i := 0; i < n; i++ {
+		offset := int(staticFilterTableHeaderSize) + i*int(unsafe.Sizeof(StaticFilter{}))
+		got := *(*StaticFilter)(unsafe.Pointer(&buf[offset]))
+		want := table.StaticFilters[i]
+		if got != want {
+			t.Errorf("filter[%d] mismatch:\n got = %+v\nwant = %+v", i, got, want)
+		}
+	}
+
+	// Guard against the original bug: the bytes right after the header must be the first real
+	// filter, not a slice header. With the bug, that region would hold the slice data pointer,
+	// so the first filter's Adapter (our sentinel {1,0,...}) would not survive.
+	first := *(*StaticFilter)(unsafe.Pointer(&buf[staticFilterTableHeaderSize]))
+	if first.Adapter != (Handle{1, 0, 0, 0, 0, 0, 0, 0}) {
+		t.Errorf("region after header does not hold the first filter (slice-header bug): Adapter = %v", first.Adapter)
+	}
+}
+
+// TestMarshalStaticFilterTableEmpty ensures a zero-filter table marshals to just the 8-byte
+// header without panicking.
+func TestMarshalStaticFilterTableEmpty(t *testing.T) {
+	table := &StaticFilterTable{TableSize: 0, StaticFilters: nil}
+	buf := marshalStaticFilterTable(table)
+
+	wantSize := int(unsafe.Sizeof(InitialStaticFilterTable{})) - AnySize*int(unsafe.Sizeof(StaticFilter{}))
+	if len(buf) != wantSize {
+		t.Fatalf("empty buffer size = %d, want %d", len(buf), wantSize)
+	}
+	if got := *(*uint32)(unsafe.Pointer(&buf[0])); got != 0 {
+		t.Fatalf("header TableSize = %d, want 0", got)
+	}
+}

--- a/ndisapi_static_marshal_test.go
+++ b/ndisapi_static_marshal_test.go
@@ -25,7 +25,7 @@ func TestMarshalStaticFilterTable(t *testing.T) {
 			DirectionFlags: uint32(0x1000 + i),
 			FilterAction:   uint32(0x2000 + i),
 			ValidFields:    uint32(0x3000 + i),
-			PacketsIn:      uint64(0xAAAA0000 + i),
+			PacketsIn:      uint64(0xAAAA0000) + uint64(i),
 		}
 	}
 
@@ -38,7 +38,7 @@ func TestMarshalStaticFilterTable(t *testing.T) {
 	buf := marshalStaticFilterTable(table)
 
 	// Buffer size must match the formula used by GetPacketFilterTable.
-	wantSize := int(unsafe.Sizeof(InitialStaticFilterTable{})) + (n-AnySize)*int(unsafe.Sizeof(StaticFilter{}))
+	wantSize := int(staticFilterTableHeaderSize) + n*int(unsafe.Sizeof(StaticFilter{}))
 	if len(buf) != wantSize {
 		t.Fatalf("buffer size = %d, want %d", len(buf), wantSize)
 	}
@@ -89,7 +89,7 @@ func TestMarshalStaticFilterTableLengthIsSourceOfTruth(t *testing.T) {
 	}
 
 	// Buffer must be sized for 2 filters, not 5.
-	wantSize := int(unsafe.Sizeof(InitialStaticFilterTable{})) + (2-AnySize)*int(unsafe.Sizeof(StaticFilter{}))
+	wantSize := int(staticFilterTableHeaderSize) + 2*int(unsafe.Sizeof(StaticFilter{}))
 	if len(buf) != wantSize {
 		t.Fatalf("buffer size = %d, want %d (2 filters)", len(buf), wantSize)
 	}
@@ -110,7 +110,7 @@ func TestMarshalStaticFilterTableEmpty(t *testing.T) {
 	table := &StaticFilterTable{TableSize: 0, StaticFilters: nil}
 	buf := marshalStaticFilterTable(table)
 
-	wantSize := int(unsafe.Sizeof(InitialStaticFilterTable{})) - AnySize*int(unsafe.Sizeof(StaticFilter{}))
+	wantSize := int(staticFilterTableHeaderSize)
 	if len(buf) != wantSize {
 		t.Fatalf("empty buffer size = %d, want %d", len(buf), wantSize)
 	}


### PR DESCRIPTION
## What

`StaticFilterTable.StaticFilters` is a Go slice, so the struct begins with a
24-byte slice header, not the contiguous `STATIC_FILTER` array the driver
expects. Two bulk-store paths got this wrong, silently:

- **`SetPacketFilterTable`** passed `unsafe.Pointer(packet)` straight through —
  the driver read the slice header as `filter[0]` and installed garbage, no error.
- **`StoreTable`** overlaid `*StaticFilterTable` on a zeroed `[]byte` and indexed
  the resulting nil slice — `index out of range` panic on the first filter.

## Fix

- Add `marshalStaticFilterTable` → serializes to `[TableSize][Padding][filters…]`,
  the exact inverse of `GetPacketFilterTable`. Both paths now share the
  `staticFilterTableHeaderSize` constant so the offset can't drift (read path no
  longer hard-codes `8`).
- Filter count comes from `len(StaticFilters)`; `TableSize` is ignored on send, so
  header and data can't disagree.
- `StoreTable` now builds a real `make([]StaticFilter, n)` and delegates to the
  fixed `SetPacketFilterTable`; drops the `unsafe` import.

## Tests

- `ndisapi_static_marshal_test.go` — driver-independent, guards the slice-header
  regression and the count-from-len behavior.
- Verified against a live driver: the slice-path `SetPacketFilterTable` now
  round-trips real filter data instead of garbage, and `StoreTable` no longer
  panics (both regress on the current release).