### PR TITLE
Fix GetAdapterPacketQueueSize: wrong IOCTL and double out-pointer

### DIFF
--- a/ndisapi_adapter.go
+++ b/ndisapi_adapter.go
@@ -104,11 +104,11 @@ func (a *NdisApi) FlushAdapterPacketQueue(adapter Handle) error {
 // GetAdapterPacketQueueSize retrieves the size of the packet queue for the specified network adapter.
 func (a *NdisApi) GetAdapterPacketQueueSize(adapter Handle, size *uint32) error {
 	return a.DeviceIoControl(
-		IOCTL_NDISRD_GET_VERSION,
+		IOCTL_NDISRD_ADAPTER_QUEUE_SIZE,
 		unsafe.Pointer(&adapter),
 		uint32(len(adapter)),
-		unsafe.Pointer(&size),
-		uint32(unsafe.Sizeof(size)),
+		unsafe.Pointer(size),
+		uint32(unsafe.Sizeof(*size)),
 		nil,
 		nil,
 	)


### PR DESCRIPTION
## What

`GetAdapterPacketQueueSize` never returned a value to the caller, due to two
defects:

- **Wrong IOCTL** — it sent `IOCTL_NDISRD_GET_VERSION` instead of
  `IOCTL_NDISRD_ADAPTER_QUEUE_SIZE`, so the driver never ran the queue-size query.
- **Double out-pointer** — `size` is already `*uint32`, so `unsafe.Pointer(&size)`
  is `**uint32`: the driver wrote into the local pointer variable, never the
  caller's `uint32`. The length was also `unsafe.Sizeof(size)` (pointer width, 8)
  instead of 4. The caller's value was left untouched.

## Fix

Send `IOCTL_NDISRD_ADAPTER_QUEUE_SIZE` and pass the caller's buffer directly:
`unsafe.Pointer(size)` with `unsafe.Sizeof(*size)`. The input argument
(`&adapter` / `sizeof(HANDLE)`) is unchanged.

This matches the `CNdisApi::GetAdapterPacketQueueSize` layout in the upstream
[wiresock/ndisapi](https://github.com/wiresock/ndisapi) C++ original (in =
`&hAdapter`/`sizeof(HANDLE)`, out = `pdwSize`/`sizeof(DWORD)`), and the adjacent
`FlushAdapterPacketQueue` in this file.

## Tests

Verified against a live driver with a sentinel preloaded into the out variable
(`var qs uint32 = 0xDEADBEEF`): on the current release the sentinel survives the
call (the caller is never written); with the fix it is overwritten with a real
queue size (0 on an idle adapter). This is a thin IOCTL wrapper, so there is no
driver-independent unit test.